### PR TITLE
Add .rakutest and .rakumod file extensions

### DIFF
--- a/lib/Flow/App.pm6
+++ b/lib/Flow/App.pm6
@@ -33,7 +33,7 @@ class Flow::App {
     $!result-supply;
   }
 
-  method !perform-test(Str $dir, @extensions = ['t', 'pm6', 'pm'], :$DIR-RECURSION) {
+  method !perform-test(Str $dir, @extensions = ['rakutest', 't', 'rakumod', 'pm6', 'pm'], :$DIR-RECURSION) {
     return if $DIR-RECURSION < 0;
     if $dir.IO.e && $dir.IO.f && $dir.IO.absolute ~~ /'.' $<ext>=\w+? $/ {
       next unless $/<ext> eq any @extensions;


### PR DESCRIPTION
Since the Perl6 → Raku rename, .rakutest is now the preferred extension for tests (and .rakumod for modules), but flow was not previously running tests from files with these extensions.  With this PR, it now does.